### PR TITLE
Enable multimodal image extraction

### DIFF
--- a/job_scripts/example.json
+++ b/job_scripts/example.json
@@ -8,7 +8,8 @@
     "model_name_version": "deepseek-r1:8b",
     "check_model_name_version": "falcon3:10b",
     "concurrent": "y",
-    "use_hi_res": "y"
+    "use_hi_res": "y",
+    "use_multimodal": "n"
   },
   "files": {
     "schema_file": "example.pkl",

--- a/src/document_reader.py
+++ b/src/document_reader.py
@@ -13,7 +13,60 @@ LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.CRITICAL)
 
 
-def doc_to_elements(file, use_hi_res=False):
+from xml.etree import ElementTree as ET
+import requests
+
+
+def extract_images_from_pdf(pdf_path, output_dir):
+    """Extract images from a PDF using pdfminer if available."""
+    try:
+        from pdfminer.high_level import extract_pages
+        from pdfminer.layout import LTImage
+    except Exception:
+        print("pdfminer.six not installed; skipping image extraction")
+        return
+
+    os.makedirs(output_dir, exist_ok=True)
+    img_count = 0
+    try:
+        for page_layout in extract_pages(pdf_path):
+            for element in page_layout:
+                if isinstance(element, LTImage) and hasattr(element, "stream"):
+                    img_count += 1
+                    img_data = element.stream.get_data()
+                    img_path = os.path.join(output_dir, f"image_{img_count}.bin")
+                    with open(img_path, "wb") as img_file:
+                        img_file.write(img_data)
+    except Exception as err:
+        print(f"Failed to extract images from {pdf_path} due to {err}")
+
+
+def extract_images_from_pubmed_xml(xml_string, output_dir):
+    """Download images referenced in a PubMed XML document."""
+    os.makedirs(output_dir, exist_ok=True)
+    try:
+        root = ET.fromstring(xml_string)
+    except Exception as err:
+        print(f"Unable to parse XML for image extraction: {err}")
+        return
+
+    ns = {"xlink": "http://www.w3.org/1999/xlink"}
+    for graphic in root.findall(".//graphic", ns):
+        href = graphic.attrib.get("{http://www.w3.org/1999/xlink}href")
+        if not href:
+            continue
+        url = href
+        try:
+            r = requests.get(url)
+            if r.status_code == 200:
+                filename = os.path.basename(url)
+                with open(os.path.join(output_dir, filename), "wb") as f:
+                    f.write(r.content)
+        except Exception as err:
+            print(f"Failed to download image {url} due to {err}")
+
+
+def doc_to_elements(file, use_hi_res=False, use_multimodal=False):
     """
     Convert a document file to a structured text format.
 
@@ -32,63 +85,76 @@ def doc_to_elements(file, use_hi_res=False):
     processed_file = os.path.splitext(os.path.basename(file))[0] + '.txt'
     processed_file_path = os.path.join(processed_docs_dir, processed_file)
 
-    # If the file has already been processed, return its content
+    # Base name used for image directory
+    paper_id = os.path.splitext(os.path.basename(file))[0]
+    images_dir = os.path.join(os.getcwd(), 'images', paper_id)
+
+    # If the file has already been processed, load its content
+    formatted_output = None
     if os.path.exists(processed_file_path):
         with open(processed_file_path, 'r') as f:
-            return f.read()
+            formatted_output = f.read()
 
-    print(f"Now processing {file}")
-    elements = None
+    if formatted_output is None:
+        print(f"Now processing {file}")
+        elements = None
 
-    # Process PDF files
-    if file.endswith('.pdf'):
-        if not use_hi_res:
-            try:
-                # Use default strategy for PDF partitioning
-                elements = partition_pdf(filename=file, strategy='auto')
-            except (PDFSyntaxError, TypeError) as er:
-                print(f"Failed to process {file} due to '{er}'.")
-                return None
-        else:
-            # Check if the PDF has multiple columns
-            if has_multiple_columns(file):
-                print("Multiple columns detected, running default strategy")
+        # Process PDF files
+        if file.endswith('.pdf'):
+            if not use_hi_res:
                 try:
                     elements = partition_pdf(filename=file, strategy='auto')
                 except (PDFSyntaxError, TypeError) as er:
                     print(f"Failed to process {file} due to '{er}'.")
                     return None
             else:
-                print("Multiple columns not detected, running advanced strategy")
-                try:
-                    # Use high-resolution strategy with table structure inference
-                    elements = partition_pdf(filename=file, strategy='hi_res', infer_table_structure=True)
-                except (PDFSyntaxError, TypeError) as er:
-                    print(f"Failed to process {file} due to '{er}'.")
-                    return None
+                if has_multiple_columns(file):
+                    print("Multiple columns detected, running default strategy")
+                    try:
+                        elements = partition_pdf(filename=file, strategy='auto')
+                    except (PDFSyntaxError, TypeError) as er:
+                        print(f"Failed to process {file} due to '{er}'.")
+                        return None
+                else:
+                    print("Multiple columns not detected, running advanced strategy")
+                    try:
+                        elements = partition_pdf(filename=file, strategy='hi_res', infer_table_structure=True)
+                    except (PDFSyntaxError, TypeError) as er:
+                        print(f"Failed to process {file} due to '{er}'.")
+                        return None
 
-    # Process XML files
-    elif file.endswith('.xml'):
-        with open(file, 'r') as f:
-            xml_content = f.read()
-        formatted_output = xml_to_string(xml_content)
-        with open(processed_file_path, 'w') as f:
-            f.write(formatted_output)
-        return formatted_output
+        # Process XML files
+        elif file.endswith('.xml'):
+            with open(file, 'r') as f:
+                xml_content = f.read()
+            formatted_output = xml_to_string(xml_content)
+            with open(processed_file_path, 'w') as f:
+                f.write(formatted_output)
+        else:
+            f = open(file, 'rb')
+            try:
+                elements = partition(file)
+            except Exception as e:
+                print(f"Unstructured failed because of {e}")
 
-    # Process other file types
-    else:
-        f = open(file, 'rb')
-        try:
-            elements = partition(file)
-        except Exception as e:
-            print(f"Unstructured failed because of {e}")
+        if elements is not None and not formatted_output:
+            formatted_output = elements_to_string(convert_to_dict(elements))
 
-    # Convert elements to a formatted string output
-    formatted_output = elements_to_string(convert_to_dict(elements))
+        if formatted_output:
+            with open(processed_file_path, 'w') as f:
+                f.write(formatted_output)
 
-    # Save the processed output
-    with open(processed_file_path, 'w') as f:
-        f.write(formatted_output)
+    # If multimodal, extract images
+    if use_multimodal:
+        if file.endswith('.pdf'):
+            extract_images_from_pdf(file, images_dir)
+        elif file.endswith('.xml'):
+            if formatted_output is None:
+                with open(file, 'r') as f:
+                    xml_content = f.read()
+            else:
+                with open(file, 'r') as f:
+                    xml_content = f.read()
+            extract_images_from_pubmed_xml(xml_content, images_dir)
 
     return formatted_output

--- a/src/extract.py
+++ b/src/extract.py
@@ -52,7 +52,11 @@ def batch_extract(job_settings: JobSettings):
     # Check for Ollama binary and start server
     begin_ollama_server()
 
-    data = PromptData(model_name_version=job_settings.model_name_version, check_model_name_version=job_settings.check_model_name_version, use_openai=job_settings.use_openai, use_hi_res=job_settings.use_hi_res)
+    data = PromptData(model_name_version=job_settings.model_name_version,
+                      check_model_name_version=job_settings.check_model_name_version,
+                      use_openai=job_settings.use_openai,
+                      use_hi_res=job_settings.use_hi_res,
+                      use_multimodal=job_settings.use_multimodal)
 
     # Determine which files to process
     files_to_process = get_files_to_process(job_settings)
@@ -188,7 +192,11 @@ def extract(file_path, job_settings:JobSettings):
     Returns:
     list or None: Validated results if successful, None if extraction fails.
     '''
-    data = PromptData(model_name_version=job_settings.model_name_version, check_model_name_version=job_settings.check_model_name_version, use_openai=job_settings.use_openai, use_hi_res=job_settings.use_hi_res)
+    data = PromptData(model_name_version=job_settings.model_name_version,
+                      check_model_name_version=job_settings.check_model_name_version,
+                      use_openai=job_settings.use_openai,
+                      use_hi_res=job_settings.use_hi_res,
+                      use_multimodal=job_settings.use_multimodal)
 
     # Prepare prompt data
     data._refresh_paper_content(file_path, generate_prompt(job_settings.extract.schema_data, job_settings.extract.user_instructions, job_settings.extract.key_columns), check_prompt = job_settings.check_prompt)


### PR DESCRIPTION
## Summary
- support multimodal processing via `use_multimodal` option in job settings
- extract images from PDFs using pdfminer when enabled
- download linked images from PubMed XML documents
- pass multimodal setting through extraction pipeline
- add example JSON field for the new option

## Testing
- `python -m pytest`
- `python -m py_compile src/classes.py src/document_reader.py src/extract.py`

------
https://chatgpt.com/codex/tasks/task_e_6841dccc87f4832ab022ce592ca75c10