### PR TITLE
Enhance context handling and SI scraping

### DIFF
--- a/src/classes.py
+++ b/src/classes.py
@@ -1,5 +1,14 @@
 import os
-from src.utils import load_schema_file, generate_examples, generate_prompt, generate_check_prompt, truncate_text, get_out_id
+from src.utils import (
+    load_schema_file,
+    generate_examples,
+    generate_prompt,
+    generate_check_prompt,
+    truncate_text,
+    get_out_id,
+    get_model_context,
+    estimate_tokens,
+)
 from src.document_reader import doc_to_elements
 
 
@@ -97,6 +106,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         self.use_openai = False
         self.api_key = None
         self.check_prompt = ""
+        self.context_length = 32768
 
 
     def _update_model_name_version(self, model_name_version):
@@ -162,24 +172,31 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         # Define the search info file path
         self.files.search_info_file = os.path.join(os.getcwd(), 'search_info', f"{output_directory_id}.txt")
 
+        # Determine model context length
+        self.context_length = get_model_context(self.model_name_version)
+        if self.context_length < 32768:
+            print(
+                f"Warning: context length for {self.model_name_version} is {self.context_length}, which is below 32k"
+            )
+
 
 class PromptData():
-    def __init__(self, model_name_version, check_model_name_version, use_openai=False, use_hi_res=False, use_multimodal=False):
+    def __init__(self, model_name_version, check_model_name_version, context_length=32768, use_openai=False, use_hi_res=False, use_multimodal=False):
         self.model = model_name_version
         self.check_model_name_version = check_model_name_version
         self.use_openai = use_openai  # Track if using OpenAI API
         self.stream = False
         self.options = {
-                        "num_ctx": 32768,
+                        "num_ctx": context_length,
                         "num_predict": 2048,
                         "mirostat": 0,
                         "mirostat_tau": 0.5,
                         "mirostat_eta": 1,
                         "tfs_z": 1,
-                        "top_p": 1,
+                        "top_p": 0.1,
                         "top_k": 5,
                         "stop": ["|||"],
-                        "temperature": 0.7,
+                        "temperature": 0.1,
                         }
         self.prompt = ""
         self.paper_content = ""
@@ -198,22 +215,43 @@ class PromptData():
             self.first_print = False
         """
 
-        # Always run doc_to_elements to ensure images are captured when needed
+        max_ctx = self.options.get("num_ctx", 32768)
+
         try:
-            self.paper_content = truncate_text(doc_to_elements(file_path, self.use_hi_res, self.use_multimodal))
+            main_text = doc_to_elements(file_path, self.use_hi_res, self.use_multimodal)
         except Exception as err:
             print(f"Unable to process {file} into plaintext due to {err}")
             return True
+
+        texts = [main_text]
+
+        base = os.path.splitext(os.path.basename(file))[0]
+        si_files = sorted(
+            [f for f in os.listdir(os.path.join(os.getcwd(), "scraped_docs")) if f.startswith(base + "_SI")]
+        )
+        for si_file in si_files:
+            path = os.path.join(os.getcwd(), "scraped_docs", si_file)
+            try:
+                si_text = doc_to_elements(path, self.use_hi_res, self.use_multimodal)
+                combined = " ".join(texts + [si_text])
+                if estimate_tokens(combined) < max_ctx - 500:
+                    texts.append(si_text)
+                else:
+                    break
+            except Exception as err:
+                print(f"Unable to process {si_file} due to {err}")
+
+        self.paper_content = truncate_text("\n\n".join(texts), max_tokens=max_ctx)
         self.prompt = f"{prompt}\n\n{self.paper_content}\n\nAgain, please make sure to respond only in the specified format exactly as described, or you will cause errors.\nResponse:"
         self.check_prompt = f"{check_prompt}\n\n{self.paper_content}\n\nAgain, please only answer 'yes' or 'no' (without quotes) to let me know if we should extract information from this paper using the costly api call"
         return False
     
     def _refresh_data(self, retry_count):
         if self.use_openai:
-            self.options["temperature"] = min(0.7 + 0.1 * retry_count, 1.0)
+            self.options["temperature"] = min(0.1 + 0.05 * retry_count, 1.0)
         else:
-            self.options["temperature"] = 0.35 * retry_count
-            self.options["repeat_penalty"] = 1.1 + 0.1 * retry_count
+            self.options["temperature"] = 0.1 * retry_count
+            self.options["repeat_penalty"] = 1.1 + 0.05 * retry_count
 
     def __dict__(self):
         return {"model": self.model,
@@ -226,13 +264,13 @@ class PromptData():
         return {"model": self.check_model_name_version,
                 "stream": self.stream,
                 "options": {
-                        "num_ctx": 32768,
+                        "num_ctx": self.options.get("num_ctx", 32768),
                         "num_predict": 1,
                         "mirostat": 0,
                         "mirostat_tau": 0.5,
                         "mirostat_eta": 1,
                         "tfs_z": 1,
-                        "top_p": 1,
+                        "top_p": 0.1,
                         "top_k": 5,
                         "stop": ["|||"],
                         "temperature": 0,

--- a/src/databases/pubmed.py
+++ b/src/databases/pubmed.py
@@ -4,7 +4,12 @@ import time
 import subprocess
 import xml.etree.ElementTree as ET
 from src.extract import extract
-from src.utils import (is_file_processed, write_to_csv, begin_ollama_server)
+from src.utils import (
+    is_file_processed,
+    write_to_csv,
+    begin_ollama_server,
+    download_supplementary_material,
+)
 from src.classes import JobSettings
 
 # Constants
@@ -95,6 +100,12 @@ def pubmed_search(job_settings: JobSettings, search_terms): # concurrent=False, 
                 if root.find(".//body"):
                     with open(file_path, 'w') as f:
                         f.write(xml_data)
+
+                    # Download supplementary materials if available
+                    for supp in root.findall('.//supplementary-material'):
+                        href = supp.attrib.get('{http://www.w3.org/1999/xlink}href')
+                        if href:
+                            download_supplementary_material(href, f"pubmed_{uid}")
                     num_downloaded += 1
                     scraped_files.append(filename)
 

--- a/src/databases/science_open.py
+++ b/src/databases/science_open.py
@@ -12,7 +12,12 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from src.extract import extract
-from src.utils import (get_chrome_driver, is_file_processed, write_to_csv)
+from src.utils import (
+    get_chrome_driver,
+    is_file_processed,
+    write_to_csv,
+    download_supplementary_material,
+)
 from src.classes import JobSettings
 
 def scrape_scienceopen(job_settings:JobSettings, search_terms):  # retmax, concurrent=False, schema_file=None, user_instructions=None, model_name_version=None
@@ -170,6 +175,12 @@ def scrape_scienceopen(job_settings:JobSettings, search_terms):  # retmax, concu
                     pdf_response = requests.get(pdf_link)
                     with open(file_path, 'wb') as f:
                         f.write(pdf_response.content)
+
+                    # Attempt to download supplementary material from the page
+                    for a in soup.find_all('a', href=True):
+                        text = (a.get_text() or '').lower()
+                        if 'supplement' in text or 'supporting' in text:
+                            download_supplementary_material(a['href'], f"SO_{encoded_doi}")
 
                     count += 1
                     elapsed_time = time.time() - start_time

--- a/src/databases/unpaywall.py
+++ b/src/databases/unpaywall.py
@@ -4,7 +4,12 @@ import time
 import json
 from datetime import datetime
 from src.extract import extract
-from src.utils import (doi_to_filename, is_file_processed, write_to_csv)
+from src.utils import (
+    doi_to_filename,
+    is_file_processed,
+    write_to_csv,
+    download_supplementary_material,
+)
 from src.classes import JobSettings
 
 def read_api_count():
@@ -231,6 +236,9 @@ def unpaywall_search(job_settings:JobSettings): #, query_chunks, retmax, email, 
                         if pdf_filename:
                             scraped_files.append(pdf_filename)
                             total_downloaded += 1
+                            landing = doi_data['best_oa_location'].get('url')
+                            if landing:
+                                download_supplementary_material(landing, f"unpaywall_{doi}")
 
                             if job_settings.concurrent:
                                 try:

--- a/src/extract.py
+++ b/src/extract.py
@@ -54,6 +54,7 @@ def batch_extract(job_settings: JobSettings):
 
     data = PromptData(model_name_version=job_settings.model_name_version,
                       check_model_name_version=job_settings.check_model_name_version,
+                      context_length=job_settings.context_length,
                       use_openai=job_settings.use_openai,
                       use_hi_res=job_settings.use_hi_res,
                       use_multimodal=job_settings.use_multimodal)
@@ -194,6 +195,7 @@ def extract(file_path, job_settings:JobSettings):
     '''
     data = PromptData(model_name_version=job_settings.model_name_version,
                       check_model_name_version=job_settings.check_model_name_version,
+                      context_length=job_settings.context_length,
                       use_openai=job_settings.use_openai,
                       use_hi_res=job_settings.use_hi_res,
                       use_multimodal=job_settings.use_multimodal)


### PR DESCRIPTION
## Summary
- determine model context length via `ollama show`
- warn if context length is under 32k
- tune model generation params for scientific use
- include supplementary information when present
- adjust scrapers to fetch SI files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68470b724f20832a80ce2726591ce625