### PR TITLE
Add SI scraping and image handling

### DIFF
--- a/install_commands.txt
+++ b/install_commands.txt
@@ -19,5 +19,6 @@ pip install webdriver_manager
 
 pip install "unstructured[all-docs]"
 pip install "unstructured[local-inference]"
+pip install pdfminer.six
 pip install libmagic poppler-utils pytesseract
 conda install -y tesseract

--- a/install_commands.txt
+++ b/install_commands.txt
@@ -19,6 +19,5 @@ pip install webdriver_manager
 
 pip install "unstructured[all-docs]"
 pip install "unstructured[local-inference]"
-pip install pdfminer.six
 pip install libmagic poppler-utils pytesseract
 conda install -y tesseract

--- a/job_scripts/chr-extraction-iupac-local.json
+++ b/job_scripts/chr-extraction-iupac-local.json
@@ -5,7 +5,9 @@
     "model_name_version": "deepseek-r1:8b",
     "check_model_name_version": "falcon3:10b",
     "concurrent":"y",
-    "use_hi_res":"y"
+    "use_hi_res":"y",
+    "use_multimodal": "n",
+    "use_thinking": "y"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/example.json
+++ b/job_scripts/example.json
@@ -9,7 +9,8 @@
     "check_model_name_version": "falcon3:10b",
     "concurrent": "y",
     "use_hi_res": "y",
-    "use_multimodal": "n"
+    "use_multimodal": "n",
+    "use_thinking": "y"
   },
   "files": {
     "schema_file": "example.pkl",

--- a/job_scripts/first_time_user_test.json
+++ b/job_scripts/first_time_user_test.json
@@ -4,7 +4,11 @@
     "maybe_search_terms": ["absorption wavelength", "emission wavelength","fluorescence quantum yield"],
     "auto": true,
     "model_name_version": "mistral:7b-instruct-v0.2-q8_0",
-    "concurrent":"n"
+    "check_model_name_version": "mistral:7b-instruct-v0.2-q8_0",
+    "concurrent":"n",
+    "use_hi_res": "y",
+    "use_multimodal": "n",
+    "use_thinking": "y"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/mof-extraction-config.json
+++ b/job_scripts/mof-extraction-config.json
@@ -5,7 +5,10 @@
     "auto": true,
     "model_name_version": "deepseek-r1:32b",
     "check_model_name_version": "phi4:14b-q8_0",
-    "concurrent": "y"
+    "concurrent": "y",
+    "use_hi_res": "y",
+    "use_multimodal": "n",
+    "use_thinking": "y"
   },
   "files": {
     "schema_file": "mof-extraction-schema.pkl",

--- a/job_scripts/pka-extraction-config.json
+++ b/job_scripts/pka-extraction-config.json
@@ -3,7 +3,11 @@
     "def_search_terms": ["pKa", "values"],
     "maybe_search_terms": ["none"],
     "model_name_version": "nemotron:latest",
-    "concurrent":"y"
+    "check_model_name_version": "nemotron:latest",
+    "concurrent":"y",
+    "use_hi_res": "y",
+    "use_multimodal": "n",
+    "use_thinking": "y"
   },
   "files": {
     "schema_file": "pka-extraction-schema.pkl",

--- a/job_scripts/spec_multimodal.json
+++ b/job_scripts/spec_multimodal.json
@@ -17,11 +17,11 @@
       "organic compound",
       "luminophore"
     ],
-    "model_name_version": "deepseek-r1:8b",
-    "check_model_name_version": "falcon3:10b",
+    "model_name_version": "gemma3:4b-it-fp16",
+    "check_model_name_version": "gemma3:4b-it-fp16",
     "concurrent": "y",
     "use_hi_res": "y",
-    "use_multimodal": "n",
+    "use_multimodal": "y",
     "use_thinking": "y"
   },
   "files": {

--- a/src/classes.py
+++ b/src/classes.py
@@ -216,6 +216,10 @@ class PromptData():
             if os.path.isfile(img_file):
                 with open(img_file, 'rb') as img_f:
                     imgs.append(base64.b64encode(img_f.read()).decode('utf-8'))
+        if not imgs:
+            print(f"No images found in {directory}")
+        else:
+            print(f"Found {len(imgs)} images in {directory}")
         return imgs
 
     def _refresh_paper_content(self,file,prompt,check_prompt):
@@ -242,6 +246,7 @@ class PromptData():
             paper_id = os.path.splitext(os.path.basename(file))[0]
             main_img_dir = os.path.join(os.getcwd(), 'images', paper_id)
             self.images = self._load_images_from_dir(main_img_dir)
+            print(f"Loaded {len(self.images)} images from {main_img_dir}")
 
             si_files = sorted(glob.glob(os.path.join(os.getcwd(), 'scraped_docs', f"{paper_id}_SI*")))
             self.si_images = []
@@ -254,6 +259,8 @@ class PromptData():
                 si_id = os.path.splitext(os.path.basename(si_file))[0]
                 si_dir = os.path.join(os.getcwd(), 'images', si_id)
                 self.si_images.extend(self._load_images_from_dir(si_dir))
+            if si_files:
+                print(f"Loaded {len(self.si_images)} images from {len(si_files)} SI files")
         else:
             self.images = []
             self.si_images = []

--- a/src/classes.py
+++ b/src/classes.py
@@ -1,4 +1,6 @@
 import os
+import base64
+import glob
 from src.utils import (
     load_schema_file,
     generate_examples,
@@ -201,6 +203,16 @@ class PromptData():
         self.use_hi_res = use_hi_res
         self.use_multimodal = use_multimodal
         self.first_print = True
+        self.images = []
+        self.si_images = []
+
+    def _load_images_from_dir(self, directory):
+        imgs = []
+        for img_file in sorted(glob.glob(os.path.join(directory, '*'))):
+            if os.path.isfile(img_file):
+                with open(img_file, 'rb') as img_f:
+                    imgs.append(base64.b64encode(img_f.read()).decode('utf-8'))
+        return imgs
 
     def _refresh_paper_content(self,file,prompt,check_prompt):
         file_path = os.path.join(os.getcwd(), 'scraped_docs', file)
@@ -221,6 +233,26 @@ class PromptData():
         except Exception as err:
             print(f"Unable to process {file} into plaintext due to {err}")
             return True
+
+        if self.use_multimodal and self.supports_vision:
+            paper_id = os.path.splitext(os.path.basename(file))[0]
+            main_img_dir = os.path.join(os.getcwd(), 'images', paper_id)
+            self.images = self._load_images_from_dir(main_img_dir)
+
+            si_files = sorted(glob.glob(os.path.join(os.getcwd(), 'scraped_docs', f"{paper_id}_SI*")))
+            self.si_images = []
+            for si_file in si_files:
+                try:
+                    doc_to_elements(si_file, self.use_hi_res, self.use_multimodal)
+                except Exception as err:
+                    print(f"Unable to process {si_file} for images due to {err}")
+                    continue
+                si_id = os.path.splitext(os.path.basename(si_file))[0]
+                si_dir = os.path.join(os.getcwd(), 'images', si_id)
+                self.si_images.extend(self._load_images_from_dir(si_dir))
+        else:
+            self.images = []
+            self.si_images = []
         self.prompt = f"{prompt}\n\n{self.paper_content}\n\nAgain, please make sure to respond only in the specified format exactly as described, or you will cause errors.\nResponse:"
         self.check_prompt = f"{check_prompt}\n\n{self.paper_content}\n\nAgain, please only answer 'yes' or 'no' (without quotes) to let me know if we should extract information from this paper using the costly api call"
         return False
@@ -233,17 +265,20 @@ class PromptData():
             self.options["repeat_penalty"] = 1.1 + 0.1 * retry_count
 
     def __dict__(self):
-        return {
+        data = {
             "model": self.model,
             "stream": self.stream,
             "options": self.options,
             "think": self.supports_thinking,
             "prompt": self.prompt,
         }
+        if self.use_multimodal and self.supports_vision:
+            data["images"] = self.images + self.si_images
+        return data
                 
     def __check__(self):
         ctx_len = self.options.get("num_ctx", 32768)
-        return {
+        data = {
             "model": self.check_model_name_version,
             "stream": self.stream,
             "options": {
@@ -260,4 +295,7 @@ class PromptData():
             "think": False,
             "prompt": self.check_prompt,
         }
+        if self.use_multimodal and self.supports_vision:
+            data["images"] = self.images
+        return data
 

--- a/src/classes.py
+++ b/src/classes.py
@@ -95,6 +95,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         self.concurrent = False
         self.use_hi_res = False
         self.use_multimodal = False
+        self.use_thinking = False
         self.def_search_terms = []
         self.maybe_search_terms = []
         self.query_chunks = []
@@ -149,6 +150,8 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
                 self.use_hi_res = bool(val.lower() == "y")
             elif key.lower() == "use_multimodal":
                 self.use_multimodal = bool(val.lower() == "y")
+            elif key.lower() == "use_thinking":
+                self.use_thinking = bool(val.lower() == "y")
             else:
                 print(f"JSON key '{key}' not recognized.")
     
@@ -174,7 +177,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
 
 
 class PromptData():
-    def __init__(self, model_name_version, check_model_name_version, use_openai=False, use_hi_res=False, use_multimodal=False):
+    def __init__(self, model_name_version, check_model_name_version, use_openai=False, use_hi_res=False, use_multimodal=False, use_thinking=False):
         self.model = model_name_version
         self.check_model_name_version = check_model_name_version
         self.use_openai = use_openai  # Track if using OpenAI API
@@ -202,6 +205,7 @@ class PromptData():
         self.check_prompt = ""
         self.use_hi_res = use_hi_res
         self.use_multimodal = use_multimodal
+        self.use_thinking = use_thinking
         self.first_print = True
         self.images = []
         self.si_images = []
@@ -269,7 +273,7 @@ class PromptData():
             "model": self.model,
             "stream": self.stream,
             "options": self.options,
-            "think": self.supports_thinking,
+            "think": self.use_thinking and self.supports_thinking,
             "prompt": self.prompt,
         }
         if self.use_multimodal and self.supports_vision:

--- a/src/document_reader.py
+++ b/src/document_reader.py
@@ -174,6 +174,8 @@ def doc_to_elements(file, use_hi_res=False, use_multimodal=False):
         with open(processed_file_path, 'r') as f:
             formatted_output = f.read()
 
+    xml_content = None
+
     if formatted_output is None:
         print(f"Now processing {file}")
         elements = None
@@ -229,10 +231,7 @@ def doc_to_elements(file, use_hi_res=False, use_multimodal=False):
             count = extract_images_from_pdf(file, images_dir)
             print(f"Image extraction complete for {file}: {count} images saved to {images_dir}")
         elif file.endswith('.xml'):
-            if formatted_output is None:
-                with open(file, 'r') as f:
-                    xml_content = f.read()
-            else:
+            if xml_content is None:
                 with open(file, 'r') as f:
                     xml_content = f.read()
             count = extract_images_from_pubmed_xml(xml_content, images_dir)

--- a/src/extract.py
+++ b/src/extract.py
@@ -56,7 +56,8 @@ def batch_extract(job_settings: JobSettings):
                       check_model_name_version=job_settings.check_model_name_version,
                       use_openai=job_settings.use_openai,
                       use_hi_res=job_settings.use_hi_res,
-                      use_multimodal=job_settings.use_multimodal)
+                      use_multimodal=job_settings.use_multimodal,
+                      use_thinking=job_settings.use_thinking)
 
     # Determine which files to process
     files_to_process = get_files_to_process(job_settings)
@@ -198,7 +199,8 @@ def extract(file_path, job_settings:JobSettings):
                       check_model_name_version=job_settings.check_model_name_version,
                       use_openai=job_settings.use_openai,
                       use_hi_res=job_settings.use_hi_res,
-                      use_multimodal=job_settings.use_multimodal)
+                      use_multimodal=job_settings.use_multimodal,
+                      use_thinking=job_settings.use_thinking)
 
     # Prepare prompt data
     data._refresh_paper_content(file_path, generate_prompt(job_settings.extract.schema_data, job_settings.extract.user_instructions, job_settings.extract.key_columns), check_prompt = job_settings.check_prompt)

--- a/src/utils.py
+++ b/src/utils.py
@@ -368,6 +368,12 @@ def xml_to_string(xml_string):
             formatted_output += f"Caption: {text}\n\n"
         elif tag == "table":
             formatted_output += f"Table: {text}\n\n"
+        elif tag in ["graphic", "media"]:
+            href = element.attrib.get('{http://www.w3.org/1999/xlink}href') or element.attrib.get('href')
+            if href:
+                formatted_output += f"[{href}]"
+            else:
+                formatted_output += "[Image]"
         elif tag not in [
             "ref", "element-citation", "person-group", "name", "surname",
             "given-names", "article-title", "source", "year", "volume",


### PR DESCRIPTION
## Summary
- support supplementary info downloads for PubMed and ChemRxiv
- include vision images from supplementary info when building prompts

## Testing
- `python -m py_compile src/databases/pubmed.py src/databases/arxiv.py src/classes.py`

------
https://chatgpt.com/codex/tasks/task_e_68473cce5d7c832ab5ec786dd0c13b8b