### PR TITLE
Add target type support

### DIFF
--- a/dataModels/chromophores.pkl
+++ b/dataModels/chromophores.pkl
@@ -1,45 +1,37 @@
 Key Columns: 1
 
 1 - Type: 'str'
-1 - Name: 'iupac_name'
-1 - Description: 'A parseable chemical name (IUPAC or a common name, must be resolvable by a typical name-to-structure tool).'
-1 - Min Length: 5
-1 - Max Length: 500
-1 - Required Substrings:
-1 - Blacklisted Substrings: '@', '#', '$', '%', '^', '&', '*', '_', '+', '=', '[', ']', '{', '}', '|', '\\', ':', ';', '"', "'", '<', '>', '/', '?'
+1 - Name: 'solvent'
+1 - Description: 'The solvent used for the spectroscopic measurements, if provided.'
 
-2 - Type: 'str'
-2 - Name: 'solvent'
-2 - Description: 'The solvent used for the spectroscopic measurements, if provided.'
+2 - Type: 'float'
+2 - Name: 'peak_absorption'
+2 - Description: 'Peak absorption wavelength in nm, typically between 200 and 1100 nm.'
+2 - Min Value: 200
+2 - Max Value: 1100
 
 3 - Type: 'float'
-3 - Name: 'peak_absorption'
-3 - Description: 'Peak absorption wavelength in nm, typically between 200 and 1100 nm.'
+3 - Name: 'peak_emission'
+3 - Description: 'Peak emission wavelength in nm, typically between 200 and 1100 nm.'
 3 - Min Value: 200
 3 - Max Value: 1100
 
 4 - Type: 'float'
-4 - Name: 'peak_emission'
-4 - Description: 'Peak emission wavelength in nm, typically between 200 and 1100 nm.'
-4 - Min Value: 200
-4 - Max Value: 1100
+4 - Name: 'quantum_yield'
+4 - Description: 'Quantum yield as a decimal value between 0 and 1.'
+4 - Min Value: 0
+4 - Max Value: 1
 
-5 - Type: 'float'
-5 - Name: 'quantum_yield'
-5 - Description: 'Quantum yield as a decimal value between 0 and 1.'
-5 - Min Value: 0
-5 - Max Value: 1
+5 - Type: 'str'
+5 - Name: 'molar_absorptivity'
+5 - Description: 'The molar absorptivity (extinction coefficient) in L/(mol·cm). If a wavelength is specified, include it in parentheses, e.g., \"1.2e4 (350 nm)\".'
 
-6 - Type: 'str'
-6 - Name: 'molar_absorptivity'
-6 - Description: 'The molar absorptivity (extinction coefficient) in L/(mol·cm). If a wavelength is specified, include it in parentheses, e.g., \"1.2e4 (350 nm)\".'
+6 - Type: 'float'
+6 - Name: 'lifetime'
+6 - Description: 'Photoluminescence or phosphorescence lifetime (in ns). If multiple lifetimes are listed, provide the primary or average value.'
+6 - Min Value: 0
+6 - Max Value: 100000
 
-7 - Type: 'float'
-7 - Name: 'lifetime'
-7 - Description: 'Photoluminescence or phosphorescence lifetime (in ns). If multiple lifetimes are listed, provide the primary or average value.'
-7 - Min Value: 0
-7 - Max Value: 100000
-
-8 - Type: 'str'
-8 - Name: 'comments'
-8 - Description: 'Any additional relevant details about the molecule or its measurements.'
+7 - Type: 'str'
+7 - Name: 'comments'
+7 - Description: 'Any additional relevant details about the molecule or its measurements.'

--- a/dataModels/example.pkl
+++ b/dataModels/example.pkl
@@ -1,25 +1,17 @@
 Key Columns: 1
 
-1 - Type: 'str'
-1 - Name: 'iupac_name'
-1 - Description: 'A parseable chemical name (IUPAC or a well-known common name).'
-1 - Min Length: 5
-1 - Max Length: 500
-1 - Required Substrings:
-1 - Blacklisted Substrings: '@', '#', '$', '%', '^', '&', '*', '_', '+', '=', '[', ']', '{', '}', '|', '\\', ':', ';', '"', "'", '<', '>', '/', '?'
+1 - Type: 'float'
+1 - Name: 'melting_point'
+1 - Description: 'Melting point in °C.'
+1 - Min Value: -200
+1 - Max Value: 3000
 
 2 - Type: 'float'
-2 - Name: 'melting_point'
-2 - Description: 'Melting point in °C.'
+2 - Name: 'boiling_point'
+2 - Description: 'Boiling point in °C.'
 2 - Min Value: -200
-2 - Max Value: 3000
+2 - Max Value: 6000
 
-3 - Type: 'float'
-3 - Name: 'boiling_point'
-3 - Description: 'Boiling point in °C.'
-3 - Min Value: -200
-3 - Max Value: 6000
-
-4 - Type: 'str'
-4 - Name: 'comments'
-4 - Description: 'Any extra notes or context (e.g., measurement conditions).'
+3 - Type: 'str'
+3 - Name: 'comments'
+3 - Description: 'Any extra notes or context (e.g., measurement conditions).'

--- a/dataModels/pka-extraction-schema.pkl
+++ b/dataModels/pka-extraction-schema.pkl
@@ -1,36 +1,31 @@
 Key Columns: 1,2,3
 
-1 - Type: 'str'
-1 - Name: 'iupac_name'
-1 - Description: 'The IUPAC name of the compound for which pKa is reported.'
-1 - Max Length: 500
+1 - Type: 'float'
+1 - Name: 'pka_value'
+1 - Description: 'The reported pKa value of the compound.'
+1 - Min Value: -100
+1 - Max Value: 100
 
-2 - Type: 'float'
-2 - Name: 'pka_value'
-2 - Description: 'The reported pKa value of the compound.'
-2 - Min Value: -100
-2 - Max Value: 100
+2 - Type: 'str'
+2 - Name: 'solvent'
+2 - Description: 'The solvent used for the pKa measurement, if provided.'
 
-3 - Type: 'str'
-3 - Name: 'solvent'
-3 - Description: 'The solvent used for the pKa measurement, if provided.'
+3 - Type: 'float'
+3 - Name: 'temperature'
+3 - Description: 'The temperature at which the pKa was measured, in Kelvin. If given in Celsius, add 273.15 to convert to Kelvin.'
+3 - Min Value: 0
+3 - Max Value: 1000
 
-4 - Type: 'float'
-4 - Name: 'temperature'
-4 - Description: 'The temperature at which the pKa was measured, in Kelvin. If given in Celsius, add 273.15 to convert to Kelvin.'
-4 - Min Value: 0
-4 - Max Value: 1000
+4 - Type: 'str'
+4 - Name: 'functional_group'
+4 - Description: 'The functional group associated with the reported pKa, if specified and required to differentiate between different reported pKa values for the same compound.'
 
-5 - Type: 'str'
-5 - Name: 'functional_group'
-5 - Description: 'The functional group associated with the reported pKa, if specified and required to differentiate between different reported pKa values for the same compound.'
+5 - Type: 'float'
+5 - Name: 'uncertainty'
+5 - Description: 'The reported uncertainty or error in the pKa measurement.'
+5 - Min Value: 0
+5 - Max Value: 5
 
-6 - Type: 'float'
-6 - Name: 'uncertainty'
-6 - Description: 'The reported uncertainty or error in the pKa measurement.'
-6 - Min Value: 0
-6 - Max Value: 5
-
-7 - Type: 'str'
-7 - Name: 'additional_info'
-7 - Description: 'Any additional relevant information about the pKa measurement or compound.'
+6 - Type: 'str'
+6 - Name: 'additional_info'
+6 - Description: 'Any additional relevant information about the pKa measurement or compound.'

--- a/job_scripts/chr-extraction-iupac-local.json
+++ b/job_scripts/chr-extraction-iupac-local.json
@@ -5,7 +5,8 @@
     "model_name_version": "deepseek-r1:8b",
     "check_model_name_version": "falcon3:10b",
     "concurrent":"y",
-    "use_hi_res":"y"
+    "use_hi_res":"y",
+    "target_type": "small_molecule"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/example.json
+++ b/job_scripts/example.json
@@ -8,7 +8,8 @@
     "model_name_version": "deepseek-r1:8b",
     "check_model_name_version": "falcon3:10b",
     "concurrent": "y",
-    "use_hi_res": "y"
+    "use_hi_res": "y",
+    "target_type": "small_molecule"
   },
   "files": {
     "schema_file": "example.pkl",

--- a/job_scripts/first_time_user_test.json
+++ b/job_scripts/first_time_user_test.json
@@ -4,7 +4,8 @@
     "maybe_search_terms": ["absorption wavelength", "emission wavelength","fluorescence quantum yield"],
     "auto": true,
     "model_name_version": "mistral:7b-instruct-v0.2-q8_0",
-    "concurrent":"n"
+    "concurrent":"n",
+    "target_type": "small_molecule"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/pka-extraction-config.json
+++ b/job_scripts/pka-extraction-config.json
@@ -3,7 +3,8 @@
     "def_search_terms": ["pKa", "values"],
     "maybe_search_terms": ["none"],
     "model_name_version": "nemotron:latest",
-    "concurrent":"y"
+    "concurrent":"y",
+    "target_type": "small_molecule"
   },
   "files": {
     "schema_file": "pka-extraction-schema.pkl",

--- a/job_scripts/spec.json
+++ b/job_scripts/spec.json
@@ -20,7 +20,8 @@
     "model_name_version": "deepseek-r1:8b",
     "check_model_name_version": "falcon3:10b",
     "concurrent": "y",
-    "use_hi_res": "y"
+    "use_hi_res": "y",
+    "target_type": "small_molecule"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/src/classes.py
+++ b/src/classes.py
@@ -1,5 +1,13 @@
 import os
-from src.utils import load_schema_file, generate_examples, generate_prompt, generate_check_prompt, truncate_text, get_out_id
+from src.utils import (
+    load_schema_file,
+    generate_examples,
+    generate_prompt,
+    generate_check_prompt,
+    truncate_text,
+    get_out_id,
+    prepend_target_column,
+)
 from src.document_reader import doc_to_elements
 
 
@@ -87,6 +95,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         self.def_search_terms = []
         self.maybe_search_terms = []
         self.query_chunks = []
+        self.target_type = "small_molecule"
         self.model_name_version = "nemotron:latest"
         self.model_name = "nemotron"
         self.model_version = "latest"
@@ -136,6 +145,8 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
                 self.concurrent = bool(val.lower() == "y")
             elif key.lower() == "use_hi_res":
                 self.use_hi_res = bool(val.lower() == "y")
+            elif key.lower() == "target_type":
+                self.target_type = val
             else:
                 print(f"JSON key '{key}' not recognized.")
     
@@ -147,6 +158,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         # Process Secondary extraction parameters.
         ## Set up extraction parameters
         self.extract.schema_data, self.extract.key_columns = load_schema_file(self.files.schema)
+        self.extract.schema_data = prepend_target_column(self.extract.schema_data, self.target_type)
         self.extract.num_columns = len(self.extract.schema_data)
         self.extract.headers = [self.extract.schema_data[column_number]['name'] for column_number in range(1, self.extract.num_columns + 1)] + ['paper']
         self.extract.prompt = generate_prompt(self.extract.schema_data, self.extract.user_instructions, self.extract.key_columns)

--- a/src/utils.py
+++ b/src/utils.py
@@ -471,6 +471,35 @@ def select_schema_file():
             print("Invalid choice. Please try again.")
 
 
+# Built-in column definitions for different chemical targets
+BUILTIN_TARGET_COLUMNS = {
+    "small_molecule": {
+        "type": "str",
+        "name": "molecule_name",
+        "description": "Name of the small molecule (IUPAC or common name).",
+    },
+    "protein": {
+        "type": "str",
+        "name": "protein_name",
+        "description": "Name or identifier of the protein of interest.",
+    },
+    "peptide": {
+        "type": "str",
+        "name": "peptide_name",
+        "description": "Name or sequence of the peptide of interest.",
+    },
+}
+
+
+def prepend_target_column(schema_data, target_type):
+    """Prepend a built-in target column to the schema."""
+    info = BUILTIN_TARGET_COLUMNS.get(target_type.lower(), BUILTIN_TARGET_COLUMNS["small_molecule"])
+    new_schema = {1: info}
+    for idx in sorted(schema_data.keys()):
+        new_schema[idx + 1] = schema_data[idx]
+    return new_schema
+
+
 def load_schema_file(schema_file):
     """
     Loads and parses a schema file.


### PR DESCRIPTION
## Summary
- support selecting a chemical target type via `target_type` in job configs
- prepend the appropriate column in the schema using built-in defaults
- remove the manual name column from example schemas
- update example job config files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685037edb4e8832ab88cb48bc08c2c88