### PR TITLE
Implement solvent validation with water fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ Be sure to replace example_small_molecule.json with the actual file you want to 
 
 Example json files for small molecules, proteins, and peptides can be found in job_scripts.
 Each configuration can optionally include a `use_comments` setting (`"y"` or `"n"`) to control
-whether a trailing comments column is added automatically.
+whether a trailing comments column is added automatically. A similar `use_solvent` setting
+(`"y"` or `"n"`) toggles a built-in solvent column that expects a SMILES string or common name.
+If `use_solvent` is enabled, you can also set `assume_water` (`"y"` or `"n"`). When `assume_water`
+is on and the model outputs `null` for the solvent column, the value will automatically be filled
+with the SMILES string for water (`O`) without further validation.
+Common solvents like water and ethanol are resolved through a built-in lookup
+table before any online database queries.
 
 ## Key Components
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ is on and the model outputs `null` for the solvent column, the value will automa
 with the SMILES string for water (`O`) without further validation.
 Common solvents like water and ethanol are resolved through a built-in lookup
 table before any online database queries.
+The `use_decimer` option (`"y"` or `"n"`) controls whether images are processed
+with DECIMER to extract additional SMILES strings from figures.
 
 ## Key Components
 

--- a/job_scripts/chr-extraction-iupac-local.json
+++ b/job_scripts/chr-extraction-iupac-local.json
@@ -7,6 +7,7 @@
     "concurrent":"y",
     "use_hi_res":"y",
     "use_multimodal": "n",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_thinking": "y",
     "use_comments": "y",

--- a/job_scripts/chr-extraction-iupac-local.json
+++ b/job_scripts/chr-extraction-iupac-local.json
@@ -9,7 +9,9 @@
     "use_multimodal": "n",
     "target_type": "small_molecule",
     "use_thinking": "y",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/example_peptide.json
+++ b/job_scripts/example_peptide.json
@@ -10,6 +10,7 @@
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",
+    "use_decimer": "y",
     "target_type": "peptide",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/example_peptide.json
+++ b/job_scripts/example_peptide.json
@@ -11,7 +11,9 @@
     "use_hi_res": "y",
     "use_multimodal": "y",
     "target_type": "peptide",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "example_peptide.pkl",

--- a/job_scripts/example_protein.json
+++ b/job_scripts/example_protein.json
@@ -10,6 +10,7 @@
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",
+    "use_decimer": "y",
     "target_type": "protein",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/example_protein.json
+++ b/job_scripts/example_protein.json
@@ -11,7 +11,9 @@
     "use_hi_res": "y",
     "use_multimodal": "y",
     "target_type": "protein",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "example_protein.pkl",

--- a/job_scripts/example_small_molecule.json
+++ b/job_scripts/example_small_molecule.json
@@ -11,7 +11,9 @@
     "use_hi_res": "y",
     "use_multimodal": "y",
     "target_type": "small_molecule",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "example_small_molecule.pkl",

--- a/job_scripts/example_small_molecule.json
+++ b/job_scripts/example_small_molecule.json
@@ -10,6 +10,7 @@
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/first_time_user_test.json
+++ b/job_scripts/first_time_user_test.json
@@ -10,7 +10,9 @@
     "use_multimodal": "n",
     "use_thinking": "y",
     "target_type": "small_molecule",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/first_time_user_test.json
+++ b/job_scripts/first_time_user_test.json
@@ -9,6 +9,7 @@
     "use_hi_res": "y",
     "use_multimodal": "n",
     "use_thinking": "y",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/mof-extraction-config.json
+++ b/job_scripts/mof-extraction-config.json
@@ -9,6 +9,7 @@
     "use_hi_res": "y",
     "use_multimodal": "n",
     "use_thinking": "y",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/mof-extraction-config.json
+++ b/job_scripts/mof-extraction-config.json
@@ -8,7 +8,11 @@
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "n",
-    "use_thinking": "y"
+    "use_thinking": "y",
+    "target_type": "small_molecule",
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "mof-extraction-schema.pkl",

--- a/job_scripts/pka-extraction-config.json
+++ b/job_scripts/pka-extraction-config.json
@@ -9,7 +9,9 @@
     "use_multimodal": "n",
     "use_thinking": "y",
     "target_type": "small_molecule",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "pka-extraction-schema.pkl",

--- a/job_scripts/pka-extraction-config.json
+++ b/job_scripts/pka-extraction-config.json
@@ -8,6 +8,7 @@
     "use_hi_res": "y",
     "use_multimodal": "n",
     "use_thinking": "y",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/spec.json
+++ b/job_scripts/spec.json
@@ -24,7 +24,9 @@
     "use_multimodal": "n",
     "use_thinking": "y",
     "target_type": "small_molecule",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/spec.json
+++ b/job_scripts/spec.json
@@ -23,6 +23,7 @@
     "use_hi_res": "y",
     "use_multimodal": "n",
     "use_thinking": "y",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_comments": "y",
     "use_solvent": "y",

--- a/job_scripts/spec_multimodal.json
+++ b/job_scripts/spec_multimodal.json
@@ -24,7 +24,9 @@
     "use_multimodal": "y",
     "use_thinking": "y",
     "target_type": "small_molecule",
-    "use_comments": "y"
+    "use_comments": "y",
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
     "schema_file": "chromophores.pkl",

--- a/job_scripts/spec_multimodal.json
+++ b/job_scripts/spec_multimodal.json
@@ -23,6 +23,7 @@
     "use_hi_res": "y",
     "use_multimodal": "y",
     "use_thinking": "y",
+    "use_decimer": "y",
     "target_type": "small_molecule",
     "use_comments": "y",
     "use_solvent": "y",

--- a/src/classes.py
+++ b/src/classes.py
@@ -99,6 +99,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         self.use_hi_res = False
         self.use_multimodal = False
         self.use_thinking = False
+        self.use_decimer = False
         self.use_comments = True
         self.use_solvent = False
         self.assume_water = False
@@ -159,6 +160,8 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
                 self.use_multimodal = bool(val.lower() == "y")
             elif key.lower() == "use_thinking":
                 self.use_thinking = bool(val.lower() == "y")
+            elif key.lower() == "use_decimer":
+                self.use_decimer = bool(val.lower() == "y")
             elif key.lower() == "use_comments":
                 self.use_comments = bool(val.lower() == "y")
             elif key.lower() == "use_solvent":

--- a/src/classes.py
+++ b/src/classes.py
@@ -10,6 +10,7 @@ from src.utils import (
     get_out_id,
     get_model_info,
     prepend_target_column,
+    insert_solvent_column,
     append_comments_column,
 )
 from src.document_reader import doc_to_elements
@@ -99,6 +100,8 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         self.use_multimodal = False
         self.use_thinking = False
         self.use_comments = True
+        self.use_solvent = False
+        self.assume_water = False
         self.target_type = "small_molecule"
         self.def_search_terms = []
         self.maybe_search_terms = []
@@ -158,6 +161,10 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
                 self.use_thinking = bool(val.lower() == "y")
             elif key.lower() == "use_comments":
                 self.use_comments = bool(val.lower() == "y")
+            elif key.lower() == "use_solvent":
+                self.use_solvent = bool(val.lower() == "y")
+            elif key.lower() == "assume_water":
+                self.assume_water = bool(val.lower() == "y")
             elif key.lower() == "target_type":
                 self.target_type = val
             else:
@@ -172,6 +179,8 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         ## Set up extraction parameters
         self.extract.schema_data, _ = load_schema_file(self.files.schema)
         self.extract.schema_data = prepend_target_column(self.extract.schema_data, self.target_type)
+        if self.use_solvent:
+            self.extract.schema_data = insert_solvent_column(self.extract.schema_data)
         if self.use_comments:
             self.extract.schema_data = append_comments_column(self.extract.schema_data)
         self.extract.key_columns = [1]

--- a/src/extract.py
+++ b/src/extract.py
@@ -172,6 +172,7 @@ def batch_extract(job_settings: JobSettings):
                     job_settings.extract.key_columns,
                     job_settings.target_type,
                     verify_target=allow_verification,
+                    assume_water=job_settings.assume_water,
                 )
 
                 if validated_result:
@@ -362,6 +363,7 @@ def single_file_extract(job_settings: JobSettings, data: PromptData, file_path):
                 job_settings.extract.key_columns,
                 job_settings.target_type,
                 verify_target=allow_verification,
+                assume_water=job_settings.assume_water,
             )
             print(f"Validated Result:\n{validated_result}")
             if not validated_result:

--- a/src/extract.py
+++ b/src/extract.py
@@ -101,16 +101,19 @@ def batch_extract(job_settings: JobSettings):
                 job_settings.check_prompt,
                 check_only=False,
             )
-            
-            print("Attempting to pull SMILES from images in paper...")
-            smiles_list = extract_smiles_for_paper(file_path)
-            if smiles_list:
-                extra = (
-                    "We ran automated SMILES extraction from all images in this paper and obtained these SMILES strings, "
-                    "which may or may not be relevant to your current extraction task:\n" + str(smiles_list) + "\n"
-                )
-                data.prompt += "\n" + extra
-                print(f"Found smiles: \n {str(smiles_list)}\n")
+
+            if job_settings.use_decimer:
+                print("Attempting to pull SMILES from images in paper...")
+                smiles_list = extract_smiles_for_paper(file_path)
+                if smiles_list:
+                    extra = (
+                        "We ran automated SMILES extraction from all images in this paper and obtained these SMILES strings, "
+                        "which may or may not be relevant to your current extraction task:\n" + str(smiles_list) + "\n"
+                    )
+                    data.prompt += "\n" + extra
+                    print(f"Found smiles: \n {str(smiles_list)}\n")
+            else:
+                print("DECIMER extraction disabled")
         else:
             print("No SMILES found")
             data.images = []
@@ -293,15 +296,18 @@ def single_file_extract(job_settings: JobSettings, data: PromptData, file_path):
             check_prompt=job_settings.check_prompt,
             check_only=False,
         )
-        print("Attempting to pull SMILES from images in paper...")
-        smiles_list = extract_smiles_for_paper(file_path)
-        if smiles_list:
-            extra = (
-                "We ran automated SMILES extraction from all images in this paper and obtained these SMILES strings, "
-                "which may or may not be relevant to your current extraction task:\n" + str(smiles_list) + "\n"
-            )
-            data.prompt += "\n" + extra
-            print(f"Found smiles: \n {str(smiles_list)}\n")
+        if job_settings.use_decimer:
+            print("Attempting to pull SMILES from images in paper...")
+            smiles_list = extract_smiles_for_paper(file_path)
+            if smiles_list:
+                extra = (
+                    "We ran automated SMILES extraction from all images in this paper and obtained these SMILES strings, "
+                    "which may or may not be relevant to your current extraction task:\n" + str(smiles_list) + "\n"
+                )
+                data.prompt += "\n" + extra
+                print(f"Found smiles: \n {str(smiles_list)}\n")
+        else:
+            print("DECIMER extraction disabled")
     else:
         print("No SMILES found")
         data.images = []


### PR DESCRIPTION
## Summary
- set `use_solvent` to `"y"` and add `assume_water` option in all job scripts
- document solvent options in README
- add built-in solvent SMILES dictionary
- validate solvent column like a small molecule and fill `O` when null
- pass `assume_water` setting through extraction pipeline

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852db67b38c832a83c1a7d6de6f650f