### PR TITLE
Support `reaction` and `general` target modes, add per-column validation, and include example job/schema files

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ before your schema columns.
 - `reaction`: prepends **two** columns:
   1. `reactants` (validated as SMILES)
   2. `products` (validated as SMILES)
+  - You can use an empty schema file if you only want these two built-in columns.
 - `general`: **no built-in target columns are injected**.
 
 Optional columns:
@@ -201,4 +202,3 @@ Unstructured
 Ollama
 
 For more detailed information on each module and function, please refer to the inline documentation in the source code.
-

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ LoA (Librarian of Alexandria) is a comprehensive tool designed for researchers, 
 
 ## Usage
 
-LoA can be used in two modes: Interactive (UI) mode and Automatic mode. 
+LoA can be used in two run styles:
+- **Interactive mode** (`python main.py`) for prompt-driven setup.
+- **Automatic mode** (`python main.py -auto <job.json>`) for reproducible jobs.
 
 ### Interactive Mode
 
@@ -63,7 +65,16 @@ file found in the `scraped_docs` directory. This mode is useful when you have
 already downloaded all the papers you want to analyze. Any directories inside
 `scraped_docs` are ignored.
 
-Example json files for small molecules, proteins, and peptides can be found in job_scripts.
+Example json files for common workflows can be found in `job_scripts/`.
+Recommended starter templates:
+- `example_small_molecule.json` + `example_small_molecule.pkl`
+- `example_protein.json` + `example_protein.pkl`
+- `example_peptide.json` + `example_peptide.pkl`
+- `example_reaction.json` + `example_reaction.pkl`
+- `example_general.json` + `example_general.pkl`
+
+The `example_general` pair demonstrates schema-level `Validation Mode` usage
+for mixed-type extraction in a single schema.
 The decimer_synthesis.json configuration focuses on synthesis papers rich in
 chemical figures so DECIMER insertion can be tested easily.
 Each configuration can optionally include a `use_comments` setting (`"y"` or `"n"`) to control
@@ -86,6 +97,54 @@ curl https://api.openai.com/v1/models \
   -H "Authorization: Bearer $OPENAI_API_KEY"
 ```
 When `use_openai` is enabled, model files are not downloaded through Ollama.
+
+## Target Modes and Column Injection
+
+The `target_type` setting controls which built-in leading columns are injected
+before your schema columns.
+
+- `small_molecule` *(default)*: prepends `molecule_name`, validated as SMILES/name.
+- `protein`: prepends `protein_name`, validated as sequence/name.
+- `peptide`: prepends `peptide_name`, validated as sequence/name.
+- `polymer`: prepends `polymer_bigsmiles`, validated as BigSMILES.
+- `reaction`: prepends **two** columns:
+  1. `reactants` (validated as SMILES)
+  2. `products` (validated as SMILES)
+- `general`: **no built-in target columns are injected**.
+
+Optional columns:
+- `use_solvent: "y"` inserts a solvent column after built-in target columns
+  (for `reaction`, it is inserted after `products`).
+- `use_comments: "y"` appends a trailing `comments` column.
+
+## Per-Column Validation in General Mode (and Any Mode)
+
+LoA now supports schema-level column validation via an optional
+`Validation Mode` field inside schema files. This lets you validate specific
+columns with different validators, regardless of the selected `target_type`.
+
+Supported validation modes:
+- `small_molecule`
+- `protein`
+- `peptide`
+- `polymer`
+- `reaction` (treated as small-molecule SMILES validation per column)
+
+### Example schema fragment
+
+```
+1 - Type: str
+1 - Name: catalyst
+1 - Description: catalyst identity
+1 - Validation Mode: small_molecule
+2 - Type: str
+2 - Name: enzyme
+2 - Description: enzyme used
+2 - Validation Mode: protein
+```
+
+With `target_type: "general"`, these two columns stay exactly where you define
+them and are validated using their respective modes.
 
 ## Key Components
 
@@ -142,6 +201,4 @@ Unstructured
 Ollama
 
 For more detailed information on each module and function, please refer to the inline documentation in the source code.
-
-
 

--- a/dataModels/example_general.pkl
+++ b/dataModels/example_general.pkl
@@ -1,0 +1,21 @@
+Key Columns: 1,2
+1 - Type: 'str'
+1 - Name: 'enzyme'
+1 - Description: 'Protein/enzyme name or sequence associated with the experiment.'
+1 - Validation Mode: protein
+
+2 - Type: 'str'
+2 - Name: 'ligand'
+2 - Description: 'Small molecule ligand represented as SMILES or a resolvable name.'
+2 - Validation Mode: small_molecule
+
+3 - Type: 'float'
+3 - Name: 'ic50_nM'
+3 - Description: 'IC50 value in nM.'
+3 - Min Value: 0
+3 - Max Value: 100000000
+
+4 - Type: 'str'
+4 - Name: 'polymer_additive'
+4 - Description: 'Optional polymer additive, reported as BigSMILES when available.'
+4 - Validation Mode: polymer

--- a/dataModels/example_reaction.pkl
+++ b/dataModels/example_reaction.pkl
@@ -1,0 +1,13 @@
+1 - Type: 'float'
+1 - Name: 'yield_percent'
+1 - Description: 'Isolated or reported reaction yield in percent.'
+1 - Min Value: 0
+1 - Max Value: 100
+
+2 - Type: 'str'
+2 - Name: 'conditions'
+2 - Description: 'Key reaction conditions such as catalyst, base, and temperature.'
+
+3 - Type: 'str'
+3 - Name: 'reference_label'
+3 - Description: 'Any reaction label used in the paper (e.g., Scheme 2, Entry 5).'

--- a/job_scripts/example_general.json
+++ b/job_scripts/example_general.json
@@ -1,21 +1,21 @@
 {
   "settings": {
-    "def_search_terms": ["peptide activity", "IC50"],
-    "maybe_search_terms": ["none"],
+    "def_search_terms": ["bioconjugate", "inhibitor"],
+    "maybe_search_terms": ["binding assay"],
     "model_name_version": "gemma3:4b-it-fp16",
     "check_model_name_version": "gemma3:4b-it-fp16",
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",
     "use_decimer": "n",
-    "target_type": "peptide",
+    "target_type": "general",
     "use_comments": "y",
     "use_solvent": "n",
     "assume_water": "n"
   },
   "files": {
-    "schema_file": "example_peptide.pkl",
-    "results_csv": "./results/example_peptide.csv"
+    "schema_file": "example_general.pkl",
+    "results_csv": "./results/example_general.csv"
   },
   "scrape": {
     "pubmed": "y",
@@ -23,12 +23,12 @@
     "scienceOpen": "n",
     "unpaywall": "n",
     "customdb": "n",
-    "retmax": 10,
+    "retmax": 20,
     "base_url": "",
     "email": "youremail@example.com"
   },
   "extract": {
-    "user_instructions": "Extract activity, IC50, and reported modifications for peptides. Provide sequences or common names in the first column.",
+    "user_instructions": "Extract mixed biochemical records. Respect column-level validation modes from the schema and write null when values are not available.",
     "max_retries": 1,
     "ollama_url": "http://localhost:11434"
   }

--- a/job_scripts/example_protein.json
+++ b/job_scripts/example_protein.json
@@ -1,20 +1,17 @@
 {
   "settings": {
-    "def_search_terms": [
-      "molecular weight",
-      "protein function"
-    ],
-    "maybe_search_terms": [""],
+    "def_search_terms": ["molecular weight", "protein function"],
+    "maybe_search_terms": ["none"],
     "model_name_version": "gemma3:4b-it-fp16",
     "check_model_name_version": "gemma3:4b-it-fp16",
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",
-    "use_decimer": "y",
+    "use_decimer": "n",
     "target_type": "protein",
     "use_comments": "y",
-    "use_solvent": "y",
-    "assume_water": "y"
+    "use_solvent": "n",
+    "assume_water": "n"
   },
   "files": {
     "schema_file": "example_protein.pkl",

--- a/job_scripts/example_reaction.json
+++ b/job_scripts/example_reaction.json
@@ -1,21 +1,21 @@
 {
   "settings": {
-    "def_search_terms": ["peptide activity", "IC50"],
-    "maybe_search_terms": ["none"],
+    "def_search_terms": ["reaction yield", "synthetic route"],
+    "maybe_search_terms": ["catalyst", "temperature"],
     "model_name_version": "gemma3:4b-it-fp16",
     "check_model_name_version": "gemma3:4b-it-fp16",
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",
-    "use_decimer": "n",
-    "target_type": "peptide",
+    "use_decimer": "y",
+    "target_type": "reaction",
     "use_comments": "y",
-    "use_solvent": "n",
-    "assume_water": "n"
+    "use_solvent": "y",
+    "assume_water": "y"
   },
   "files": {
-    "schema_file": "example_peptide.pkl",
-    "results_csv": "./results/example_peptide.csv"
+    "schema_file": "example_reaction.pkl",
+    "results_csv": "./results/example_reaction.csv"
   },
   "scrape": {
     "pubmed": "y",
@@ -23,12 +23,12 @@
     "scienceOpen": "n",
     "unpaywall": "n",
     "customdb": "n",
-    "retmax": 10,
+    "retmax": 20,
     "base_url": "",
     "email": "youremail@example.com"
   },
   "extract": {
-    "user_instructions": "Extract activity, IC50, and reported modifications for peptides. Provide sequences or common names in the first column.",
+    "user_instructions": "Extract reaction entries where both reactants and products can be represented as SMILES. Capture yield and conditions from the paper text.",
     "max_retries": 1,
     "ollama_url": "http://localhost:11434"
   }

--- a/job_scripts/example_small_molecule.json
+++ b/job_scripts/example_small_molecule.json
@@ -1,14 +1,11 @@
 {
   "settings": {
-    "def_search_terms": [
-      "melting point",
-      "boiling point"
-    ],
+    "def_search_terms": ["melting point", "boiling point"],
     "maybe_search_terms": ["density"],
-  "model_name_version": "gemma3:4b-it-fp16",
-  "check_model_name_version": "gemma3:4b-it-fp16",
-  "use_openai": "n",
-  "api_key": "",
+    "model_name_version": "gemma3:4b-it-fp16",
+    "check_model_name_version": "gemma3:4b-it-fp16",
+    "use_openai": "n",
+    "api_key": "",
     "concurrent": "y",
     "use_hi_res": "y",
     "use_multimodal": "y",

--- a/src/classes.py
+++ b/src/classes.py
@@ -190,7 +190,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
             elif key.lower() == "skip_check":
                 self.skip_check = bool(val.lower() == "y")
             elif key.lower() == "target_type":
-                # Accept: small_molecule (default), protein, peptide, polymer.
+                # Accept: small_molecule (default), protein, peptide, polymer, reaction, general.
                 self.target_type = normalize_target_type(val)
             else:
                 print(f"JSON key '{key}' not recognized.")
@@ -203,17 +203,26 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         
         # Process Secondary extraction parameters.
         ## Set up extraction parameters
-        self.extract.schema_data, _ = load_schema_file(self.files.schema)
-        self.extract.schema_data = prepend_target_column(
-            self.extract.schema_data, self.target_type
-        )
+        self.extract.schema_data, schema_key_columns = load_schema_file(self.files.schema)
+        if self.target_type != "general":
+            prepend_count = 2 if self.target_type == "reaction" else 1
+            self.extract.schema_data = prepend_target_column(
+                self.extract.schema_data, self.target_type
+            )
+            if schema_key_columns:
+                schema_key_columns = [col + prepend_count for col in schema_key_columns]
         if self.use_solvent:
-            self.extract.schema_data = insert_solvent_column(self.extract.schema_data)
+            self.extract.schema_data = insert_solvent_column(
+                self.extract.schema_data, self.target_type
+            )
         if self.use_comments:
             self.extract.schema_data = append_comments_column(self.extract.schema_data)
-        self.extract.key_columns = [1]
-        if self.use_solvent:
-            self.extract.key_columns.append(2)
+        if self.target_type == "general":
+            self.extract.key_columns = schema_key_columns
+        elif self.target_type == "reaction":
+            self.extract.key_columns = [1]
+        else:
+            self.extract.key_columns = [1]
         self.extract.num_columns = len(self.extract.schema_data)
         self.extract.headers = [self.extract.schema_data[column_number]['name'] for column_number in range(1, self.extract.num_columns + 1)] + ['paper']
         self.extract.prompt = generate_prompt(

--- a/src/classes.py
+++ b/src/classes.py
@@ -218,11 +218,17 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         if self.use_comments:
             self.extract.schema_data = append_comments_column(self.extract.schema_data)
         if self.target_type == "general":
-            self.extract.key_columns = schema_key_columns
+            self.extract.key_columns = schema_key_columns.copy() if schema_key_columns else []
+            if self.use_solvent and self.extract.key_columns:
+                self.extract.key_columns = [col + 1 for col in self.extract.key_columns]
         elif self.target_type == "reaction":
-            self.extract.key_columns = [1]
+            self.extract.key_columns = [1, 2]
+            if self.use_solvent:
+                self.extract.key_columns.append(3)
         else:
             self.extract.key_columns = [1]
+            if self.use_solvent:
+                self.extract.key_columns.append(2)
         self.extract.num_columns = len(self.extract.schema_data)
         self.extract.headers = [self.extract.schema_data[column_number]['name'] for column_number in range(1, self.extract.num_columns + 1)] + ['paper']
         self.extract.prompt = generate_prompt(

--- a/src/utils.py
+++ b/src/utils.py
@@ -518,6 +518,25 @@ BUILTIN_TARGET_COLUMNS = {
             "Infer and report BigSMILES from the paper's structures/text when needed."
         ),
     },
+    "reaction": [
+        {
+            "type": "str",
+            "name": "reactants",
+            "description": (
+                "Reactant SMILES string(s). Use '.' to separate multiple reactants "
+                "in the same reaction entry."
+            ),
+        },
+        {
+            "type": "str",
+            "name": "products",
+            "description": (
+                "Product SMILES string(s). Use '.' to separate multiple products "
+                "in the same reaction entry."
+            ),
+        },
+    ],
+    "general": [],
 }
 
 SUPPORTED_TARGET_TYPES = tuple(BUILTIN_TARGET_COLUMNS.keys())
@@ -531,6 +550,18 @@ def normalize_target_type(target_type: str) -> str:
         raise ValueError(
             f"Unknown target_type '{target_type}'. Supported values are: {supported}."
         )
+    return normalized
+
+
+def normalize_validation_mode(validation_mode: str) -> str:
+    """Normalize schema validation mode values."""
+    normalized = normalize_target_type(validation_mode)
+    if normalized == "general":
+        raise ValueError(
+            "Validation Mode 'general' is not supported for column validation."
+        )
+    if normalized == "reaction":
+        return "small_molecule"
     return normalized
 
 # Column added to all schemas to capture additional notes
@@ -572,6 +603,10 @@ def _target_descriptor(target_type: str) -> str:
         return t
     if t == "polymer":
         return "polymer"
+    if t == "reaction":
+        return "reactions"
+    if t == "general":
+        return "records"
     return "small molecule"
 
 
@@ -590,6 +625,11 @@ def _first_column_instruction(target_type: str, col_name: str) -> str:
             "Always provide a BigSMILES string. "
             "Do not return polymer/common names in this column."
         )
+    if descriptor == "reactions":
+        return (
+            f"The first column '{col_name}' contains reaction reactant SMILES. "
+            "Always provide SMILES directly whenever available."
+        )
     return (
         f"The first column '{col_name}' uniquely identifies each {descriptor}. "
         "Always provide a SMILES string directly if it is available. "
@@ -601,9 +641,13 @@ def _first_column_instruction(target_type: str, col_name: str) -> str:
 def prepend_target_column(schema_data, target_type):
     """Prepend a built-in target column to the schema."""
     info = BUILTIN_TARGET_COLUMNS[normalize_target_type(target_type)]
-    new_schema = {1: info}
+    info_list = info if isinstance(info, list) else [info]
+    new_schema = {}
+    for idx, column in enumerate(info_list, start=1):
+        new_schema[idx] = column
+    shift = len(info_list)
     for idx in sorted(schema_data.keys()):
-        new_schema[idx + 1] = schema_data[idx]
+        new_schema[idx + shift] = schema_data[idx]
     return new_schema
 
 
@@ -614,17 +658,22 @@ def append_comments_column(schema_data):
     return new_schema
 
 
-def insert_solvent_column(schema_data):
+def insert_solvent_column(schema_data, target_type="small_molecule"):
     """Insert the solvent column after the target column."""
+    t = normalize_target_type(target_type)
     if not schema_data:
         return {1: SOLVENT_COLUMN}
+    insertion_index = 1
+    if t == "reaction":
+        insertion_index = 2
+    elif t == "general":
+        insertion_index = 0
+
     new_schema = {}
-    inserted = False
     for idx in sorted(schema_data.keys()):
-        new_schema[idx + (1 if inserted and idx > 1 else 0)] = schema_data[idx]
-        if idx == 1 and not inserted:
-            new_schema[2] = SOLVENT_COLUMN
-            inserted = True
+        new_idx = idx + 1 if idx > insertion_index else idx
+        new_schema[new_idx] = schema_data[idx]
+    new_schema[insertion_index + 1] = SOLVENT_COLUMN
     return new_schema
 
 
@@ -700,6 +749,8 @@ def load_schema_file(schema_file):
                 elif info_type == "Blacklisted Substrings":
                     schema_data[current_column]['blacklisted_substrings'] = [substring.strip() for substring in
                                                                              info_value.split(',') if substring.strip()]
+                elif info_type == "Validation Mode":
+                    schema_data[current_column]['validation_mode'] = normalize_validation_mode(info_value)
 
     # Fill in missing 'description' keys with empty strings
     for column_data in schema_data.values():
@@ -730,18 +781,25 @@ def generate_prompt(schema_data, user_instructions, key_columns=None, target_typ
 
     # Generate schema information and diagram
     for column_number, column_data in schema_data.items():
+        validation_info = ""
+        if column_data.get("validation_mode"):
+            validation_info = f" [validated as {column_data['validation_mode']}]"
         schema_info += f"Column {column_number}: {column_data['name']} ({column_data['type']})\n"
-        schema_info += f"Description: {column_data['description']}\n\n"
+        schema_info += f"Description: {column_data['description']}{validation_info}\n\n"
         schema_diagram += f"{column_data['name']}, "
     schema_diagram = schema_diagram[:-2]
 
     # Generate key column information
     key_column_names = [schema_data[int(column)]['name'] for column in key_columns]
-    first_col_instruction = _first_column_instruction(target_type, key_column_names[0]) if key_columns else ""
+    first_col_instruction = (
+        _first_column_instruction(target_type, key_column_names[0])
+        if key_columns and normalize_target_type(target_type) != "general"
+        else ""
+    )
     if key_columns:
         uniqueness_instruction = (
             "Duplicate target values are allowed when other extracted properties differ."
-            if normalize_target_type(target_type) == "polymer"
+            if normalize_target_type(target_type) in {"polymer", "reaction", "general"}
             else "Ensure that the values in this column are unique within each paper."
         )
         key_column_info = f"{first_col_instruction} {uniqueness_instruction}"
@@ -766,6 +824,16 @@ def generate_prompt(schema_data, user_instructions, key_columns=None, target_typ
             "- Include descriptor IDs (e.g., [$1], [<1], [>1]) only when multiple orthogonal connection types are required.\n"
             "- Encode only connectivity supported by the paper; do not invent unsupported stereochemistry/sequence statistics/end-group populations.\n"
             "- Keep output format identical: comma-separated CSV rows only."
+        )
+    elif normalized_target_type == "reaction":
+        target_output_instruction = (
+            "- For reactions, both reactants and products columns must contain SMILES.\n"
+            "- Use '.' to separate multiple species within reactants or products."
+        )
+    elif normalized_target_type == "general":
+        target_output_instruction = (
+            "- Follow each schema column's description carefully.\n"
+            "- If a column has a validation mode, format values to satisfy that validator."
         )
     else:
         target_output_instruction = (
@@ -1356,6 +1424,36 @@ def validate_target_value(value, target_type):
     return _smiles_from_string(value)
 
 
+def _get_column_index_by_name(schema_data, column_name):
+    """Return 0-based index for a named column, or None if absent."""
+    for idx, col in schema_data.items():
+        if col.get("name") == column_name:
+            return idx - 1
+    return None
+
+
+def _build_validation_modes(schema_data, target_type, verify_target):
+    """Build a map of 0-based column indexes to validation modes."""
+    mode_map = {}
+    normalized_target_type = normalize_target_type(target_type)
+    if verify_target and normalized_target_type not in {"general"}:
+        if normalized_target_type == "reaction":
+            mode_map[0] = "small_molecule"
+            mode_map[1] = "small_molecule"
+        else:
+            mode_map[0] = normalized_target_type
+
+    solvent_idx = _get_column_index_by_name(schema_data, "solvent")
+    if solvent_idx is not None:
+        mode_map[solvent_idx] = "small_molecule"
+
+    for idx, col_data in schema_data.items():
+        validation_mode = col_data.get("validation_mode")
+        if validation_mode:
+            mode_map[idx - 1] = validation_mode
+    return mode_map
+
+
 def validate_result(parsed_result, schema_data, examples, key_columns=None, target_type="small_molecule", verify_target=True, assume_water=False):
     """
     Validate the parsed result against the schema and remove any invalid or example rows.
@@ -1386,6 +1484,9 @@ def validate_result(parsed_result, schema_data, examples, key_columns=None, targ
         if len(ex_row) == num_columns:
             example_rows.append(tuple(cell.strip() for cell in ex_row))
     example_rows = set(example_rows)
+
+    validation_modes = _build_validation_modes(schema_data, target_type, verify_target)
+    solvent_idx = _get_column_index_by_name(schema_data, "solvent")
 
     # Check if headers are present in the parsed result
     headers_present = False
@@ -1440,44 +1541,37 @@ def validate_result(parsed_result, schema_data, examples, key_columns=None, targ
                 print(f"Skipping row with all null key columns: {row}")
                 row_valid = False
 
-        # Only the first (target) column changes validation behavior by target_type.
-        # For target_type == "polymer", validate_target_value(...) routes column 1 through
-        # _bigsmiles_from_string(...) and preserves the trimmed BigSMILES text (no RDKit
-        # canonicalization). Other target types keep their existing target validators.
-        if row_valid and verify_target:
-            if validated_row[0].lower() == 'null':
-                row_valid = False
-            else:
-                canonical = validate_target_value(validated_row[0], target_type)
-                if canonical is None:
-                    print(
-                        f"Warning: Unable to resolve '{validated_row[0]}' to a valid {target_type}."
-                    )
-                    row_valid = False
+        if row_valid:
+            for idx, mode in sorted(validation_modes.items()):
+                if idx >= len(validated_row):
+                    continue
+                value = validated_row[idx]
+                if str(value).lower() == "null":
+                    if assume_water and solvent_idx == idx:
+                        validated_row[idx] = SOLVENT_SMILES_LOOKUP.get('water', 'O')
+                    else:
+                        row_valid = False
+                        break
                 else:
-                    validated_row[0] = canonical
-
-        if row_valid and has_solvent_column(schema_data):
-            # Solvent handling always stays in standard small-molecule space, even when
-            # extracting polymer targets. This isolates polymer BigSMILES validation to the
-            # target column and prevents side effects in solvent canonicalization.
-            solvent_val = validated_row[1]
-            if solvent_val.lower() == 'null':
-                if assume_water:
-                    validated_row[1] = SOLVENT_SMILES_LOOKUP.get('water', 'O')
-            else:
-                canonical_solvent = validate_target_value(solvent_val, "small_molecule")
-                if canonical_solvent is None:
-                    print(
-                        f"Warning: Unable to resolve solvent '{solvent_val}' to a valid small_molecule."
-                    )
-                    row_valid = False
-                else:
-                    validated_row[1] = canonical_solvent
+                    canonical = validate_target_value(value, mode)
+                    if canonical is None:
+                        print(
+                            f"Warning: Unable to resolve '{value}' to a valid {mode}."
+                        )
+                        row_valid = False
+                        break
+                    validated_row[idx] = canonical
 
         # Require at least one data field (excluding comments) when a target is present
         if row_valid:
-            start_idx = 1 + int(has_solvent_column(schema_data))
+            normalized_target_type = normalize_target_type(target_type)
+            start_idx = 0
+            if normalized_target_type in {"small_molecule", "protein", "peptide", "polymer"}:
+                start_idx = 1
+            elif normalized_target_type == "reaction":
+                start_idx = 2
+            if has_solvent_column(schema_data):
+                start_idx += 1
             if has_comments_column(schema_data):
                 end_idx = -1
             else:
@@ -1552,6 +1646,7 @@ def generate_examples(schema_data, num_examples=3, target_type="small_molecule")
         '"{[>][<]CCO[>][<]}"',
         '"{[$]CC(c1ccccc1)[$]}"',
     ]
+    reaction_examples = ['"CCO.CC(=O)O"', '"CC(=O)O"', '"CCN.CCO"']
     for _ in range(num_examples):
         example_row = []
         for column_number, column_data in schema_data.items():
@@ -1564,6 +1659,12 @@ def generate_examples(schema_data, num_examples=3, target_type="small_molecule")
                 and column_type == 'str'
             ):
                 example_value = polymer_targets[(_ + column_number) % len(polymer_targets)]
+            elif (
+                normalized_target_type == "reaction"
+                and column_number in {1, 2}
+                and column_type == "str"
+            ):
+                example_value = reaction_examples[(_ + column_number) % len(reaction_examples)]
             elif allowed_values:
                 example_value = random.choice(allowed_values)
             elif column_type == 'str':

--- a/src/utils.py
+++ b/src/utils.py
@@ -1315,6 +1315,31 @@ def _smiles_from_string(value):
     return None
 
 
+def _reaction_side_from_string(value):
+    """Validate a dot-separated reaction side and canonicalize each component.
+
+    Accepts strings like ``A.B.C`` and validates each molecule token
+    independently using the standard small-molecule resolver.
+    """
+    if value is None:
+        return None
+    side = str(value).strip()
+    if not side:
+        return None
+
+    parts = [part.strip() for part in side.split(".")]
+    if not parts or any(not part for part in parts):
+        return None
+
+    canonical_parts = []
+    for part in parts:
+        canonical = _smiles_from_string(part)
+        if canonical is None:
+            return None
+        canonical_parts.append(canonical)
+    return ".".join(canonical_parts)
+
+
 def _bigsmiles_from_string(value):
     """Validate and normalize a BigSMILES string using lightweight heuristics."""
     if value is None:
@@ -1426,6 +1451,8 @@ def validate_target_value(value, target_type):
         return _peptide_sequence_from_string(value)
     if t == "polymer":
         return _bigsmiles_from_string(value)
+    if t == "reaction":
+        return _reaction_side_from_string(value)
     return _smiles_from_string(value)
 
 
@@ -1583,7 +1610,7 @@ def validate_result(parsed_result, schema_data, examples, key_columns=None, targ
             else:
                 end_idx = None
             data_fields = validated_row[start_idx:end_idx] if end_idx is not None else validated_row[start_idx:]
-            if all(str(v).lower() == 'null' for v in data_fields):
+            if data_fields and all(str(v).lower() == 'null' for v in data_fields):
                 print(f"Skipping row with no data fields: {row}")
                 row_valid = False
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -704,6 +704,11 @@ def load_schema_file(schema_file):
     with open(schema_file, 'r') as f:
         lines = f.readlines()
 
+    # Allow empty schema files (e.g., reaction-only extractions that rely only on
+    # built-in columns like reactants/products).
+    if not lines:
+        return {}, []
+
     key_columns = []
     if lines[0].startswith("Key Columns:"):
         key_columns = [int(column.strip()) for column in lines[0].split(':')[1].strip().split(',') if column.strip()]

--- a/src/utils.py
+++ b/src/utils.py
@@ -1547,11 +1547,12 @@ def validate_result(parsed_result, schema_data, examples, key_columns=None, targ
                     continue
                 value = validated_row[idx]
                 if str(value).lower() == "null":
-                    if assume_water and solvent_idx == idx:
-                        validated_row[idx] = SOLVENT_SMILES_LOOKUP.get('water', 'O')
-                    else:
-                        row_valid = False
-                        break
+                    if solvent_idx == idx:
+                        if assume_water:
+                            validated_row[idx] = SOLVENT_SMILES_LOOKUP.get('water', 'O')
+                        continue
+                    row_valid = False
+                    break
                 else:
                     canonical = validate_target_value(value, mode)
                     if canonical is None:


### PR DESCRIPTION
### Motivation
- Add first-class support for reaction-style and general/mixed extraction workflows so targets that require multiple builtin columns (e.g., reactants/products) and mixed-type schemas can be handled. 
- Provide per-column `Validation Mode` in schemas so different columns can be validated with appropriate validators (SMILES, protein sequence, BigSMILES, etc.).
- Update docs and supply ready-to-run example job and schema files to help users adopt the new modes and validation features.

### Description
- Refresh `README.md` to document two run styles (`Interactive` and `Automatic`), new `target_type` options including `reaction` and `general`, per-column `Validation Mode`, and recommended example job/schema pairs under `job_scripts/` and `dataModels/`.
- Add example schema files `dataModels/example_general.pkl` and `dataModels/example_reaction.pkl` and new job configs `job_scripts/example_general.json` and `job_scripts/example_reaction.json`, and update several existing example job files to match new defaults and flags.
- Implement multi-column builtin target support and per-column validation in `src/utils.py`, including `BUILTIN_TARGET_COLUMNS` entries for `reaction` and `general`, `normalize_validation_mode`, `_build_validation_modes`, `_get_column_index_by_name`, updated `prepend_target_column` and `insert_solvent_column`, parsing of `Validation Mode` in `load_schema_file`, prompt generation improvements, reaction/example generation, and a rewritten `validate_result` to validate columns according to the constructed mode map and handle `assume_water` logic.
- Update `src/classes.py` to load schema key columns, adjust how target columns are prepended (including two cols for `reaction`), adjust solvent insertion, compute `extract.key_columns` correctly for `general`/`reaction`, and regenerate prompts/examples consistent with the new behavior.

### Testing
- Ran the project's automated test suite with `pytest -q` against the modified code and the suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3f337770832abc06fe87361f7a84)