### PR TITLE
Add strict auto-mode CSV double-check pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The `example_general` pair demonstrates schema-level `Validation Mode` usage
 for mixed-type extraction in a single schema.
 The decimer_synthesis.json configuration focuses on synthesis papers rich in
 chemical figures so DECIMER insertion can be tested easily.
+The `example_double_check.json` configuration runs a strict row-level
+verification pass over an existing extraction CSV and writes a new CSV with an
+additional `double_check` yes/no column.
 Each configuration can optionally include a `use_comments` setting (`"y"` or `"n"`) to control
 whether a trailing comments column is added automatically. A similar `use_solvent` setting
 (`"y"` or `"n"`) toggles a built-in solvent column that expects a SMILES string or common name.

--- a/job_scripts/example_double_check.json
+++ b/job_scripts/example_double_check.json
@@ -1,0 +1,20 @@
+{
+  "settings": {
+    "model_name_version": "gemma3:4b-it-fp16",
+    "check_model_name_version": "gemma3:4b-it-fp16",
+    "use_openai": "n",
+    "api_key": "",
+    "use_hi_res": "y",
+    "use_multimodal": "y",
+    "use_decimer": "y",
+    "use_decimer_segmentation": "y"
+  },
+  "files": {
+    "source_csv": "./results/example_small_molecule.csv",
+    "results_csv": "./results/example_small_molecule_double_checked.csv"
+  },
+  "double_check": {
+    "max_retries": 2,
+    "ollama_url": "http://localhost:11434"
+  }
+}

--- a/main.py
+++ b/main.py
@@ -219,6 +219,11 @@ def print_all_settings(job_settings: JobSettings):
     print("#   Using OpenAI: " + str(job_settings.use_openai))
     if job_settings.use_openai:
         print("#   API Key Present: " + str(bool(job_settings.api_key)))
+    if job_settings.run_double_check:
+        print("# Double-Check Settings:")
+        print("#   Source CSV: " + str(job_settings.files.source_csv))
+        print("#   Output CSV: " + str(job_settings.files.csv))
+        print("#   Maximum retries: " + str(job_settings.double_check.max_retries))
     print("######################################################")
     
 #################################### BEGIN MAIN ######################################
@@ -259,6 +264,9 @@ def main():
         elif task_name == "extract":
             job_settings.extract._parse_from_json(task_params)
             job_settings.run_extract = True
+        elif task_name == "double_check":
+            job_settings.double_check._parse_from_json(task_params)
+            job_settings.run_double_check = True
         else:
             print(f"Unrecognized JSON section: {task_name}. Job will not continue.\n")
             AUTO_EPICFAIL = True
@@ -300,8 +308,11 @@ def main():
     if not os.path.exists(job_settings.files.json):
         print(f"JSON file {job_settings.files.json} not found.  Exiting program.\n")
         AUTO_EPICFAIL = True
-    if not os.path.exists(job_settings.files.schema):
+    if job_settings.run_extract and not os.path.exists(job_settings.files.schema):
         print(f"SCHEMA file {job_settings.files.schema} not found.")
+        AUTO_EPICFAIL = True
+    if job_settings.run_double_check and not os.path.exists(job_settings.files.source_csv):
+        print(f"SOURCE CSV file {job_settings.files.source_csv} not found.")
         AUTO_EPICFAIL = True
     if job_settings.auto and AUTO_EPICFAIL:
         print("Error(s) encountered.  Please review logfile. Terminating program (unable to switch to interactive mode).\n")
@@ -326,6 +337,9 @@ def main():
             # Initialize ollama server if necessary?
             from src.extract import batch_extract
             batch_extract(job_settings)
+        if job_settings.run_double_check:
+            from src.extract import batch_double_check
+            batch_double_check(job_settings)
 
 if __name__ == '__main__':
     main()

--- a/src/classes.py
+++ b/src/classes.py
@@ -16,6 +16,7 @@ from src.utils import (
     append_comments_column,
     normalize_target_type,
     get_segmented_multimodal_images,
+    generate_double_check_prompt,
 )
 from src.document_reader import doc_to_elements
 
@@ -78,6 +79,7 @@ class FileSettings():
         self.json = "automatic.json"
         self.schema = "schema.pkl"
         self.csv = "results_output.csv"
+        self.source_csv = "results_output.csv"
         self.log = "LoA.log"
         self.search_info_file = "search_info.txt"
     def _parse_from_json(self,json):
@@ -88,17 +90,36 @@ class FileSettings():
                 self.log = str(val)
             elif key.lower() == "results_csv":
                 self.csv = str(val)
+            elif key.lower() == "source_csv":
+                self.source_csv = str(val)
             else:
                 print(f"Files setting '{key}' not recognized. \n")
+
+
+class DoubleCheckSettings():
+    def __init__(self):
+        self.max_retries = 2
+        self.ollama_url = "http://localhost:11434"
+
+    def _parse_from_json(self, json):
+        for key, val in json.items():
+            if key.lower() == "max_retries":
+                self.max_retries = int(val)
+            elif key.lower() == "ollama_url":
+                self.ollama_url = str(val)
+            else:
+                print(f"Double-check setting '{key}' not recognized. \n")
 
 class JobSettings(): ## Contains subsettings as well for each of the job types.
     def __init__(self):
         self.scrape = ScrapeSettings()
         self.extract = ExtractSettings()
+        self.double_check = DoubleCheckSettings()
         self.files = FileSettings()
         self.auto = False
         self.run_scrape = False
         self.run_extract= False
+        self.run_double_check = False
         self.concurrent = False
         self.use_hi_res = False
         self.use_multimodal = False
@@ -122,6 +143,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
         self.use_openai = False
         self.api_key = None
         self.check_prompt = ""
+        self.double_check_prompt = ""
 
 
     def _update_model_name_version(self, model_name_version):
@@ -200,6 +222,14 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
                 print(f"JSON key '{key}' not recognized.")
     
     def _finalize(self):
+        if self.run_double_check and not self.run_extract:
+            # Double-check mode validates rows from an existing CSV.
+            # It does not require schema loading or extraction prompt generation.
+            if not hasattr(self.files, "source_csv") or not self.files.source_csv:
+                self.files.source_csv = self.files.csv
+            self.double_check_prompt = generate_double_check_prompt()
+            return
+
         self.target_type = normalize_target_type(self.target_type)
         # Check for necessary file information, generate if missing.
         if any([self.files.csv == "results_output.csv",self.files.csv == "", self.files.csv is None]):
@@ -250,6 +280,7 @@ class JobSettings(): ## Contains subsettings as well for each of the job types.
             self.extract.user_instructions,
             self.target_type,
         )
+        self.double_check_prompt = generate_double_check_prompt()
         
         # Generate output directory ID and query chunks
         output_directory_id, self.query_chunks = get_out_id(

--- a/src/extract.py
+++ b/src/extract.py
@@ -16,6 +16,150 @@ from src.classes import JobSettings,PromptData
 from openai import OpenAI
 
 
+def _is_skippable_row(row, paper_col):
+    row_values = [str(v).strip() for k, v in row.items() if k != paper_col and k != "double_check"]
+    if not row_values:
+        return True
+    lowered = [v.lower() for v in row_values]
+    all_null = all(v in {"null", "", "none"} for v in lowered)
+    has_failed = any(v == "failed" for v in lowered)
+    return all_null or has_failed
+
+
+def batch_double_check(job_settings: JobSettings):
+    def resolve_paper_filename(paper_id):
+        candidates = [f"{paper_id}.pdf", f"{paper_id}.txt", f"{paper_id}.xml", paper_id]
+        for cand in candidates:
+            if os.path.isfile(os.path.join(os.getcwd(), "scraped_docs", cand)):
+                return cand
+        return f"{paper_id}.pdf"
+
+    if not job_settings.use_openai:
+        begin_ollama_server()
+
+    data = PromptData(
+        model_name_version=job_settings.model_name_version,
+        check_model_name_version=job_settings.check_model_name_version,
+        use_openai=job_settings.use_openai,
+        api_key=job_settings.api_key,
+        use_hi_res=job_settings.use_hi_res,
+        use_multimodal=job_settings.use_multimodal,
+        use_thinking=False,
+        use_decimer_segmentation=job_settings.use_decimer_segmentation,
+    )
+
+    with open(job_settings.files.source_csv, "r", newline="", encoding="utf-8") as src_f:
+        reader = csv.DictReader(src_f)
+        headers = list(reader.fieldnames or [])
+        if not headers:
+            raise ValueError(f"No headers found in source CSV: {job_settings.files.source_csv}")
+        paper_col = "paper" if "paper" in headers else headers[-1]
+        output_headers = headers.copy()
+        if "double_check" not in output_headers:
+            output_headers.append("double_check")
+        rows = list(reader)
+
+    output_rows = []
+    cached_paper = None
+    for idx, row in enumerate(rows, start=1):
+        base_row = {h: row.get(h, "") for h in headers}
+        print(f"Double-checking row {idx}/{len(rows)} for paper '{base_row.get(paper_col, '')}'")
+        if _is_skippable_row(base_row, paper_col):
+            base_row["double_check"] = "no"
+            output_rows.append(base_row)
+            continue
+
+        paper_id = str(base_row.get(paper_col, "")).strip()
+        if not paper_id:
+            base_row["double_check"] = "no"
+            output_rows.append(base_row)
+            continue
+
+        paper_file = resolve_paper_filename(paper_id)
+        if paper_id != cached_paper:
+            if data._refresh_paper_content(
+                paper_file,
+                job_settings.extract.prompt if job_settings.run_extract else "",
+                job_settings.check_prompt if job_settings.run_extract else "",
+                check_only=False,
+            ):
+                base_row["double_check"] = "no"
+                output_rows.append(base_row)
+                continue
+            if job_settings.use_decimer:
+                new_text, _ = extract_smiles_for_paper(paper_file, data.paper_content)
+                data.paper_content = new_text
+            cached_paper = paper_id
+
+        row_repr = ", ".join(
+            [f'{h}="{str(base_row.get(h, "")).strip()}"' for h in headers if h not in {"double_check"}]
+        )
+        prompt = (
+            f"Paper Contents:\n{data.paper_content}\n\n"
+            f"{job_settings.double_check_prompt}\n\n"
+            f"Candidate row to verify:\n{row_repr}\n\n"
+            "Does this row exist in the paper? Respond with exactly yes or no.\nResponse:"
+        )
+
+        retry_count = 0
+        decision = "no"
+        while retry_count < job_settings.double_check.max_retries:
+            try:
+                if job_settings.use_openai:
+                    client = OpenAI()
+                    parts = [{"type": "input_text", "text": prompt}]
+                    if job_settings.use_multimodal:
+                        for img in data.images + data.si_images + data.segment_images:
+                            parts.append(
+                                {"type": "input_image", "image_url": f"data:image/png;base64,{img}"}
+                            )
+                    try:
+                        resp = client.responses.create(
+                            model=job_settings.check_model_name,
+                            input=[{"role": "user", "content": parts}],
+                        )
+                        model_answer = resp.output_text
+                    except Exception:
+                        content_parts = [{"type": "text", "text": prompt}]
+                        if job_settings.use_multimodal:
+                            for img in data.images + data.si_images + data.segment_images:
+                                content_parts.append(
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {"url": f"data:image/png;base64,{img}"},
+                                    }
+                                )
+                        completion = client.chat.completions.create(
+                            model=job_settings.check_model_name,
+                            messages=[{"role": "user", "content": content_parts}],
+                        )
+                        model_answer = completion.choices[0].message.content
+                else:
+                    payload = data.__check__()
+                    payload["prompt"] = prompt
+                    payload["images"] = data.images + data.si_images + data.segment_images
+                    response = requests.post(
+                        f"{job_settings.double_check.ollama_url}/api/generate",
+                        json=payload,
+                    )
+                    response.raise_for_status()
+                    model_answer = response.json()["response"]
+
+                decision = "yes" if str(model_answer).strip().lower() == "yes" else "no"
+                break
+            except Exception as err:
+                retry_count += 1
+                print(f"Double-check retry {retry_count}/{job_settings.double_check.max_retries}: {err}")
+
+        base_row["double_check"] = decision
+        output_rows.append(base_row)
+
+    with open(job_settings.files.csv, "w", newline="", encoding="utf-8") as out_f:
+        writer = csv.DictWriter(out_f, fieldnames=output_headers)
+        writer.writeheader()
+        writer.writerows(output_rows)
+
+
 def get_files_to_process(job_settings:JobSettings):
     ## Process "search_info_file" to get list of files to process
     if job_settings.files.search_info_file == 'All':
@@ -488,3 +632,14 @@ def single_file_extract(job_settings: JobSettings, data: PromptData, file_path):
             retry_count += 1
             print(f"Retrying ({retry_count}/{job_settings.extract.max_retries})...")
     return None
+    def resolve_paper_filename(paper_id):
+        candidates = [
+            f"{paper_id}.pdf",
+            f"{paper_id}.txt",
+            f"{paper_id}.xml",
+            paper_id,
+        ]
+        for cand in candidates:
+            if os.path.isfile(os.path.join(os.getcwd(), "scraped_docs", cand)):
+                return cand
+        return f"{paper_id}.pdf"

--- a/src/utils.py
+++ b/src/utils.py
@@ -937,6 +937,33 @@ Your answer must be exactly "yes" or "no" with no additional text.
 Understand that answering "yes" will result in a costly extraction step, so please be certain.
 """
     return prompt
+
+
+def generate_double_check_prompt():
+    """
+    Generate a strict binary prompt for row-level verification.
+
+    Returns:
+    str: Prompt template that expects a single yes/no answer.
+    """
+    return """
+You are performing a strict binary classification task.
+
+You will be given:
+1) The full text of a scientific paper.
+2) The paper images (and segmented sub-images when available).
+3) A single CSV row that was previously extracted from this paper.
+
+Task:
+- Decide whether the provided row is supported by the paper contents and images.
+- Return "yes" only if the row clearly appears in or is directly supported by the paper.
+- If there is any uncertainty, inconsistency, or missing support, return "no".
+- Be strict: partial matches, guesses, or weak implications should be "no".
+
+Output requirements:
+- Respond with exactly one token: yes or no
+- Any answer other than exact "yes" is treated as "no"
+"""
     
 
 def parse_llm_response(response, num_columns):


### PR DESCRIPTION
### Motivation
- Provide an automated, schema-free verification pass that loads an existing extraction CSV and strictly verifies each row against the paper text and images with a binary yes/no decision. 
- Make the checker strict (return `yes` only for clear, directly supported evidence) and ensure DECIMER/DECIMER segmentation results and all multimodal images are attached to prompts for visual verification. 
- Allow this workflow to be invoked automatically from job JSON so it can be run as a distinct auto-mode task. 

### Description
- Added `DoubleCheckSettings`, a `source_csv` file option in `FileSettings`, and a `run_double_check` flag in `JobSettings`, and wired a new `double_check` section to be parsed from job JSON in `main.py`.
- Implemented `generate_double_check_prompt()` in `src/utils.py` which returns a strict binary verification prompt that requires exactly `yes` or `no`.
- Implemented `batch_double_check(job_settings)` in `src/extract.py` which loads rows from the source CSV, skips null/failed rows, loads paper text & images (including SI and DECIMER-segmented sub-images), optionally runs `extract_smiles_for_paper` to inject SMILES, and asks the check model to emit a strict `yes`/`no` for each row; results are written to a new CSV with an added `double_check` column.
- Updated `_finalize()` in `src/classes.py` to support a schema-free double-check-only mode and to generate the double-check prompt when appropriate.
- Hooked the pipeline into `main.py` so `double_check` jobs are validated and dispatched, and updated `README.md` and added `job_scripts/example_double_check.json` as a runnable example.

### Testing
- Compiled the modified modules to verify syntax and imports with `python -m compileall src/extract.py main.py src/classes.py src/utils.py`, which completed successfully.
- Project files were committed after changes (files changed: `README.md`, `main.py`, `src/classes.py`, `src/extract.py`, `src/utils.py`, and added `job_scripts/example_double_check.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e5843b00832a8889fe7ccf01cfce)